### PR TITLE
Prevent duplicate temperature points

### DIFF
--- a/src/subsystems/temperature/basic/TemperatureExchain.mts
+++ b/src/subsystems/temperature/basic/TemperatureExchain.mts
@@ -76,9 +76,13 @@ export class TemperatureExchange{
 		return report
 	}
 
-	public addTemperaturePoint(temperaturePoint: TemperaturePoint){
+        public addTemperaturePoint(temperaturePoint: TemperaturePoint){
 
-		this.temperaturePoints.push(temperaturePoint)
-	}
+                if(this.temperaturePoints.some(tp => tp.id === temperaturePoint.id)){
+                        throw new Error('temperature point already exists')
+                }
+
+                this.temperaturePoints.push(temperaturePoint)
+        }
 
 }


### PR DESCRIPTION
## Summary
- guard against duplicate temperature points in `TemperatureExchange`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'ws' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68409dd7dfdc83318a17d552598a29e9